### PR TITLE
Fix puppeteer service path

### DIFF
--- a/lib/services/puppeteer/scrapePages.js
+++ b/lib/services/puppeteer/scrapePages.js
@@ -1,5 +1,5 @@
 /**
- * Service pour effectuer des recherches web via Gmail
+ * Service pour effectuer le scraping de pages web avec Puppeteer
  */
 
 export const handleScrapesPages = async ({ pagesContent }) => {

--- a/src/app/recettes/samosas/useRecipes.js
+++ b/src/app/recettes/samosas/useRecipes.js
@@ -1,6 +1,6 @@
 import { MODEL_SOURCES } from 'app/constants';
 import { handleWebSearch } from 'lib/services/gmail/webSearch';
-import { handleScrapesPages } from 'lib/services/pupperteer/scrapePages';
+import { handleScrapesPages } from 'lib/services/puppeteer/scrapePages';
 import { useState } from 'react';
 import { extractObject } from 'src/app/agentBuilder/components/run/utils';
 import { MODELS } from 'src/app/chatInterface/constants';


### PR DESCRIPTION
## Summary
- rename pupperteer service folder to puppeteer
- update scraping comment to reference Puppeteer
- fix imports that use this service

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b7a9384083329e7be48084b15afb